### PR TITLE
Fixes many Errors related to typescript

### DIFF
--- a/examples/framework-svelte/tsconfig.json
+++ b/examples/framework-svelte/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "compilerOptions": {
+    "module": "ES2015",
+    "target": "es5"
+  }
+}


### PR DESCRIPTION
# Svelte Typescipt Issue

Fix Svelte Component Errors importing Svelte standard functions using typescript see https://github.com/snowpackjs/astro/issues/403.
Also fixes "ReferenceError: exports is not defined" see https://github.com/snowpackjs/astro/issues/969.

## Changes

- What does this change?
Configures typescript to use the `ES2015` module.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

Bug fix only.
<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
